### PR TITLE
Add launcher

### DIFF
--- a/snap/scripts/launch
+++ b/snap/scripts/launch
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ "$SNAP_ARCH" == "amd64" ]; then
+  ARCH="x86_64-linux"
+elif [ "$SNAP_ARCH" == "armhf" ]; then
+  ARCH="armv7l-linux-eabihf"
+elif [ "$SNAP_ARCH" == "arm64" ]; then
+  ARCH="aarch64-linux"
+elif [ "$SNAP_ARCH" == "i386" ]; then
+  ARCH="i686-linux"
+fi
+
+export RUBYLIB=$SNAP/lib/ruby/2.5.0:$SNAP/lib/ruby/2.5.0/$ARCH:$RUBYLIB
+
+exec "$@"
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,39 +10,32 @@ confinement: classic
 
 apps:
   ruby:
-    command: bin/ruby
-    environment:
-      RUBYLIB: $SNAP/lib/ruby/2.5.0:$SNAP/lib/ruby/2.5.0/x86_64-linux
+    command: bin/launch $SNAP/bin/ruby
   irb:
-    command: bin/ruby $SNAP/bin/irb
-    environment:
-      RUBYLIB: $SNAP/lib/ruby/2.5.0:$SNAP/lib/ruby/2.5.0/x86_64-linux
+    command: bin/launch $SNAP/bin/ruby $SNAP/bin/irb
   rdoc:
-    command: bin/ruby $SNAP/bin/rdoc
-    environment:
-      RUBYLIB: $SNAP/lib/ruby/2.5.0:$SNAP/lib/ruby/2.5.0/x86_64-linux
+    command: bin/launch $SNAP/bin/ruby $SNAP/bin/rdoc
   ri:
-    command: bin/ruby $SNAP/bin/ri
-    environment:
-      RUBYLIB: $SNAP/lib/ruby/2.5.0:$SNAP/lib/ruby/2.5.0/x86_64-linux
+    command: bin/launch $SNAP/bin/ruby $SNAP/bin/ri
   gem:
-    command: bin/ruby $SNAP/bin/gem
-    environment:
-      RUBYLIB: $SNAP/lib/ruby/2.5.0:$SNAP/lib/ruby/2.5.0/x86_64-linux
+    command: bin/launch $SNAP/bin/ruby $SNAP/bin/gem
   rake:
-    command: bin/ruby $SNAP/bin/rake
+    command: bin/launch $SNAP/bin/ruby $SNAP/bin/rake
     environment:
-      RUBYLIB: $SNAP/lib/ruby/2.5.0:$SNAP/lib/ruby/2.5.0/x86_64-linux
       GEM_HOME: $SNAP/lib/ruby/gems/2.5.0
       GEM_PATH: $SNAP/lib/ruby/gems/2.5.0
   bundle:
-    command: bin/ruby $SNAP/bin/bundle
+    command: bin/launch $SNAP/bin/ruby $SNAP/bin/bundle
     environment:
-      RUBYLIB: $SNAP/lib/ruby/2.5.0:$SNAP/lib/ruby/2.5.0/x86_64-linux
       GEM_HOME: $SNAP/lib/ruby/gems/2.5.0
       GEM_PATH: $SNAP/lib/ruby/gems/2.5.0
 
 parts:
+  launcher:
+    plugin: dump
+    source: snap/scripts
+    organize: 
+      "launch": bin/
   ruby:
     plugin: make
     source: https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz


### PR DESCRIPTION
This adds a launcher/wrapper around the ruby executable to set the path correctly for each architecture. It is needed until the following bug is fixed in snapd. https://bugs.launchpad.net/snapd/+bug/1742565

This enables support for 64 bit Intel and ARM architectures. Additional architectures can be added by simply extending the launcher script `if` section. 
