### PR TITLE
Fix description

### DIFF
--- a/snap/local/snapcraft.yaml.erb
+++ b/snap/local/snapcraft.yaml.erb
@@ -1,10 +1,11 @@
 name: ruby
 version: '<%= v %>'
-summary: Interpreter of object-oriented scripting language Ruby
+summary: Interpreter for the Ruby programming language
 description: |
-  Ruby is the interpreted scripting language for quick and easy object-oriented
-  programming. It has many features to process text files and to do system
-  management tasks (as in perl). It is simple, straight-forward, and extensible.
+  Ruby is an interpreted object-oriented programming language often
+  used for web development. It also offers many scripting features to
+  process plain text and serialized files, or manage system tasks.
+  It is simple, straightforward, and extensible.
 grade: stable
 confinement: classic
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,11 @@
 name: ruby
 version: '2.6.3'
-summary: Interpreter of object-oriented scripting language Ruby
+summary: Interpreter for the Ruby programming language
 description: |
-  Ruby is the interpreted scripting language for quick and easy object-oriented
-  programming. It has many features to process text files and to do system
-  management tasks (as in perl). It is simple, straight-forward, and extensible.
+  Ruby is an interpreted object-oriented programming language often
+  used for web development. It also offers many scripting features to
+  process plain text and serialized files, or manage system tasks.
+  It is simple, straightforward, and extensible.
 grade: stable
 confinement: classic
 


### PR DESCRIPTION
This restores the (much) improved description that got lost in a previous commit, and also updates the `snapcraft.yaml.erb` template accordingly. (The description had only been updated in the generated file and not in the template originally, so the improvement got lost when the file was regenerated.)

Unless this happens automatically via the yaml file, the website should be updated in the same way (https://snapcraft.io/ruby).