### PR TITLE
Update base to core20 from core18

### DIFF
--- a/snap/local/snapcraft.yaml.erb
+++ b/snap/local/snapcraft.yaml.erb
@@ -56,6 +56,7 @@ parts:
     override-pull: |
       snapcraftctl pull
     override-build: |
+      export DEBIAN_DISABLE_RUBYGEMS_INTEGRATION=true # avoid error: /usr/lib/ruby/vendor_ruby/rubygems/defaults/operating_system.rb:50:in `<class:Specification>': undefined method `rubyforge_project=' for class `Gem::Specification' (NameError)
       ./configure --prefix=/ --enable-shared
       make
       make extract-gems

--- a/snap/local/snapcraft.yaml.erb
+++ b/snap/local/snapcraft.yaml.erb
@@ -1,6 +1,6 @@
 name: ruby
 version: '<%= v %>'
-base: core18
+base: core20
 summary: Interpreter for the Ruby programming language
 description: |
   Ruby is an interpreted object-oriented programming language often
@@ -52,7 +52,7 @@ parts:
     source: https://cache.ruby-lang.org/pub/ruby/snapshot.tar.gz
 <% end %>
     build-packages: [gcc, curl, autoconf, bison, libssl-dev, libyaml-dev, libreadline6-dev, zlib1g-dev, libncurses5-dev, libffi-dev, libdb-dev, libgdbm-dev]
-    stage-packages: [libgdbm5]
+    stage-packages: [libgdbm6]
     override-pull: |
       snapcraftctl pull
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,7 @@ parts:
     override-pull: |
       snapcraftctl pull
     override-build: |
+      export DEBIAN_DISABLE_RUBYGEMS_INTEGRATION=true # avoid error: /usr/lib/ruby/vendor_ruby/rubygems/defaults/operating_system.rb:50:in `<class:Specification>': undefined method `rubyforge_project=' for class `Gem::Specification' (NameError)
       ./configure --prefix=/ --enable-shared
       make
       make extract-gems

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: ruby
 version: '3.0.0'
-base: core18
+base: core20
 summary: Interpreter for the Ruby programming language
 description: |
   Ruby is an interpreted object-oriented programming language often

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
     source: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-$SNAPCRAFT_PROJECT_VERSION.tar.gz
 
     build-packages: [gcc, curl, autoconf, bison, libssl-dev, libyaml-dev, libreadline6-dev, zlib1g-dev, libncurses5-dev, libffi-dev, libdb-dev, libgdbm-dev]
-    stage-packages: [libgdbm5]
+    stage-packages: [libgdbm6]
     override-pull: |
       snapcraftctl pull
     override-build: |


### PR DESCRIPTION
I met a following problem on `docs.ruby-lang.org`:

```
Oct 18 00:18:21 docs-2020.ruby-lang.org bash[2852]: /var/rubydoc/rurema-search/shared/bundle/ruby/3.0.0/gems/rroonga-11.0.6/lib/groonga.rb:48:in `require': /snap/core18/current/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /lib/x86_64-linux-gnu/libldap_r-2.4.so.2) - /var/rubydoc/rurema-search/shared/bundle/ruby/3.0.0/gems/rroonga-11.0.6/lib/groonga.so (LoadError)
Oct 18 00:18:21 docs-2020.ruby-lang.org bash[2852]:         from /var/rubydoc/rurema-search/shared/bundle/ruby/3.0.0/gems/rroonga-11.0.6/lib/groonga.rb:48:in `<top (required)>'
Oct 18 00:18:21 docs-2020.ruby-lang.org bash[2852]:         from /var/rubydoc/rurema-search/releases/20210929005334/lib/rurema_search/groonga_database.rb:5:in `require'
Oct 18 00:18:21 docs-2020.ruby-lang.org bash[2852]:         from /var/rubydoc/rurema-search/releases/20210929005334/lib/rurema_search/groonga_database.rb:5:in `<top (required)>'
Oct 18 00:18:21 docs-2020.ruby-lang.org bash[2852]:         from /var/rubydoc/rurema-search/releases/20210929005334/lib/rurema_search.rb:7:in `require'
Oct 18 00:18:21 docs-2020.ruby-lang.org bash[2852]:         from /var/rubydoc/rurema-search/releases/20210929005334/lib/rurema_search.rb:7:in `<top (required)>'
Oct 18 00:18:21 docs-2020.ruby-lang.org bash[2852]:         from /var/rubydoc/rurema-search/current/bin/bitclust-indexer:23:in `require'
Oct 18 00:18:21 docs-2020.ruby-lang.org bash[2852]:         from /var/rubydoc/rurema-search/current/bin/bitclust-indexer:23:in `<main>'
```

So I want to update glibc linked by snap.ruby.

I think this will resolve <https://github.com/ruby/snap.ruby/issues/7> too.