### PR TITLE
Add license metadata

### DIFF
--- a/snap/local/snapcraft.yaml.erb
+++ b/snap/local/snapcraft.yaml.erb
@@ -9,6 +9,7 @@ description: |
   It is simple, straightforward, and extensible.
 grade: stable
 confinement: classic
+license: Ruby
 
 environment:
   GEM_HOME: $HOME/.gem

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,7 @@ description: |
   It is simple, straightforward, and extensible.
 grade: stable
 confinement: classic
+license: Ruby
 
 environment:
   GEM_HOME: $HOME/.gem


### PR DESCRIPTION
`snap info ruby` says `license:   unset`, so I try to set.

```
vagrant@buster:~$ snap info ruby
name:      ruby
summary:   Interpreter for the Ruby programming language
publisher: Ruby core team (rubylang✓)
contact:   info@ruby-lang.org
license:   unset
description: |
  Ruby is an interpreted object-oriented programming language often used for web development. It
  also offers many scripting features to process plain text and serialized files, or manage system
  tasks. It is simple, straightforward, and extensible.
commands:
  - ruby.bundle
  - ruby.env
  - ruby.gem
  - ruby.irb
  - ruby.rake
  - ruby.rdoc
  - ruby.ri
  - ruby
snap-id:      RjAgguCDAawLSJ3IByPe0R92xlNtrfGt
tracking:     stable
refresh-date: 20 days ago, at 00:56 GMT
channels:
  stable:        3.0.2  2021-07-16 (220) 30MB classic
  candidate:     ↑
  beta:          ↑
  edge:          3.1.0  2021-10-19 (233) 33MB classic
  3.0/stable:    3.0.2  2021-10-19 (232) 33MB classic
  3.0/candidate: ↑
  3.0/beta:      ↑
  3.0/edge:      ↑
  2.7/stable:    2.7.4  2021-10-19 (231) 20MB classic
  2.7/candidate: ↑
  2.7/beta:      ↑
  2.7/edge:      ↑
  2.6/stable:    2.6.8  2021-10-19 (230) 27MB classic
  2.6/candidate: ↑
  2.6/beta:      ↑
  2.6/edge:      ↑
  2.5/stable:    2.5.9  2021-04-07 (209) 23MB classic
  2.5/candidate: ↑
  2.5/beta:      ↑
  2.5/edge:      ↑
  2.4/stable:    2.4.10 2020-04-01 (178) 26MB classic
  2.4/candidate: ↑
  2.4/beta:      ↑
  2.4/edge:      ↑
  2.3/stable:    2.3.8  2018-11-08 (109) 33MB classic
  2.3/candidate: ↑
  2.3/beta:      ↑
  2.3/edge:      ↑
installed:       3.0.2             (220) 30MB classic
```

https://snapcraft.io/docs/snapcraft-top-level-metadata#heading--license
https://spdx.org/licenses/