### PR TITLE
Use multi arch build for actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,38 @@ jobs:
   build:
     name: build with snapcraft
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - amd64
+          - arm64
+          - armhf
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+      - name: Store Ruby version
+        run: |
+          echo "RUBY_VERSION=${{ github.event.client_payload.ruby_version || github.event.inputs.ruby_version }}" >> $GITHUB_ENV
 
-      - name: Use Snapcraft
-        run: ruby build.rb ${{ github.event.inputs.ruby_version || github.event.client_payload.ruby_version }}
+      - name: Generate template file
+        run: ruby generate.rb ${{ env.RUBY_VERSION }}
+
+      - uses: docker/setup-qemu-action@v1
+
+      - uses: diddlesnaps/snapcraft-multiarch-action@v1
+        id: snapcraft
+        with:
+          architecture: ${{ matrix.platform }}
+
+      - name: Store ABI version
+        run: echo "ABI_VERSION=$(echo \"${{ env.RUBY_VERSION }}\" | cut -d '.' -f 1-2)" >> $GITHUB_ENV
+
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: ${{env.ABI_VERSION}}/edge

--- a/build.rb
+++ b/build.rb
@@ -1,16 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'erb'
-require 'fileutils'
+require_relative 'generate'
 
 archs = %w[amd64 arm64 armhf]
-
-v = ARGV[0] || '3.3.4'
-abi_v = v.split(".").tap{|v| v[-1] = "0"}.join(".")
-series_v = abi_v[0..2]
-
-yml = ERB.new(File.read("snap/local/snapcraft.yaml.erb")).result(binding)
-File.open("snap/snapcraft.yaml", "w") {|f| f.puts yml }
-
-puts "Build #{v} snap package"
 system "snapcraft remote-build --build-on=#{archs.join(",")} --launchpad-accept-public-upload"

--- a/generate.rb
+++ b/generate.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require 'erb'
+
+v = ARGV[0] || '3.3.4'
+abi_v = v.split(".").tap{|v| v[-1] = "0"}.join(".")
+series_v = abi_v[0..2]
+
+yml = ERB.new(File.read("snap/local/snapcraft.yaml.erb")).result(binding)
+File.open("snap/snapcraft.yaml", "w") {|f| f.puts yml }


### PR DESCRIPTION
Because snapcraft remote-build is difficult to run with GitHub Actions