### PR TITLE
Fix snapcraft build by dropping removed --target-arch flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: build with snapcraft
+    name: build with snapcraft (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - uses:  snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
         id: snapcraft
         with:
-          snapcraft-args: --target-arch=${{ matrix.platform }} --enable-experimental-target-arch
+          snapcraft-args: pack
 
       - name: Store ABI version
         run: echo "ABI_VERSION=$(echo ${{ env.RUBY_VERSION }} | cut -d '.' -f 1-2)" >> $GITHUB_ENV


### PR DESCRIPTION
snapcraft 9.0.0 removed the --target-arch and --enable-experimental-target-arch options, so every matrix job failed with an unrecognized-arguments error when action-build passed them through.

The matrix already builds on native amd64 and arm64 runners, so cross-compilation flags are no longer needed. This runs snapcraft pack instead, which builds for the host architecture and also avoids the deprecation warning about invoking snapcraft with no command.
