### PR TITLE
Publish snaps to versioned and latest channels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
         required: true
         default: '3.3.4'
 
+env:
+  # ABI series that also owns the default (trackless) latest channel.
+  LATEST_STABLE_TRACK: '4.0'
+
 jobs:
   build:
     name: build with snapcraft
@@ -50,7 +54,11 @@ jobs:
           ABI_VERSION=$(echo "$RUBY_VERSION" | cut -d '.' -f 1-2)
           echo "ABI_VERSION=$ABI_VERSION" >> $GITHUB_ENV
           if [[ "$RUBY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "RELEASE=$ABI_VERSION/stable,$ABI_VERSION/edge" >> $GITHUB_ENV
+            RELEASE="$ABI_VERSION/stable,$ABI_VERSION/edge"
+            if [[ "$ABI_VERSION" == "$LATEST_STABLE_TRACK" ]]; then
+              RELEASE="$RELEASE,stable"
+            fi
+            echo "RELEASE=$RELEASE" >> $GITHUB_ENV
           else
             echo "RELEASE=$ABI_VERSION/edge" >> $GITHUB_ENV
           fi
@@ -94,7 +102,11 @@ jobs:
           ABI_VERSION=$(echo "$RUBY_VERSION" | cut -d '.' -f 1-2)
           echo "ABI_VERSION=$ABI_VERSION" >> $GITHUB_ENV
           if [[ "$RUBY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "RELEASE=$ABI_VERSION/stable,$ABI_VERSION/edge" >> $GITHUB_ENV
+            RELEASE="$ABI_VERSION/stable,$ABI_VERSION/edge"
+            if [[ "$ABI_VERSION" == "$LATEST_STABLE_TRACK" ]]; then
+              RELEASE="$RELEASE,stable"
+            fi
+            echo "RELEASE=$RELEASE" >> $GITHUB_ENV
           else
             echo "RELEASE=$ABI_VERSION/edge" >> $GITHUB_ENV
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Store Ruby version
+        env:
+          RAW_RUBY_VERSION: ${{ github.event.client_payload.ruby_version || github.event.inputs.ruby_version }}
         run: |
-          echo "RUBY_VERSION=${{ github.event.client_payload.ruby_version || github.event.inputs.ruby_version }}" >> $GITHUB_ENV
+          if [[ ! "$RAW_RUBY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?$ ]]; then
+            echo "Invalid ruby version: $RAW_RUBY_VERSION" >&2
+            exit 1
+          fi
+          echo "RUBY_VERSION=$RAW_RUBY_VERSION" >> $GITHUB_ENV
 
       - name: Generate template file
         run: ruby generate.rb ${{ env.RUBY_VERSION }}
@@ -64,8 +70,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Store Ruby version
+        env:
+          RAW_RUBY_VERSION: ${{ github.event.client_payload.ruby_version || github.event.inputs.ruby_version }}
         run: |
-          echo "RUBY_VERSION=${{ github.event.client_payload.ruby_version || github.event.inputs.ruby_version }}" >> $GITHUB_ENV
+          if [[ ! "$RAW_RUBY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?$ ]]; then
+            echo "Invalid ruby version: $RAW_RUBY_VERSION" >&2
+            exit 1
+          fi
+          echo "RUBY_VERSION=$RAW_RUBY_VERSION" >> $GITHUB_ENV
 
       - name: Generate template file
         run: ruby generate.rb ${{ env.RUBY_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,15 +39,22 @@ jobs:
         with:
           snapcraft-args: --target-arch=${{ matrix.platform }} --enable-experimental-target-arch
 
-      - name: Store ABI version
-        run: echo "ABI_VERSION=$(echo ${{ env.RUBY_VERSION }} | cut -d '.' -f 1-2)" >> $GITHUB_ENV
+      - name: Determine release channel
+        run: |
+          ABI_VERSION=$(echo "$RUBY_VERSION" | cut -d '.' -f 1-2)
+          echo "ABI_VERSION=$ABI_VERSION" >> $GITHUB_ENV
+          if [[ "$RUBY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "RELEASE=$ABI_VERSION/stable,$ABI_VERSION/edge" >> $GITHUB_ENV
+          else
+            echo "RELEASE=$ABI_VERSION/edge" >> $GITHUB_ENV
+          fi
 
       - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.snapcraft.outputs.snap }}
-          release: ${{ env.ABI_VERSION }}/edge
+          release: ${{ env.RELEASE }}
 
   build-armhf:
     name: build armhf with snapcraft
@@ -70,12 +77,19 @@ jobs:
         with:
           architecture: armhf
 
-      - name: Store ABI version
-        run: echo "ABI_VERSION=$(echo ${{ env.RUBY_VERSION }} | cut -d '.' -f 1-2)" >> $GITHUB_ENV
+      - name: Determine release channel
+        run: |
+          ABI_VERSION=$(echo "$RUBY_VERSION" | cut -d '.' -f 1-2)
+          echo "ABI_VERSION=$ABI_VERSION" >> $GITHUB_ENV
+          if [[ "$RUBY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "RELEASE=$ABI_VERSION/stable,$ABI_VERSION/edge" >> $GITHUB_ENV
+          else
+            echo "RELEASE=$ABI_VERSION/edge" >> $GITHUB_ENV
+          fi
 
       - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.snapcraft.outputs.snap }}
-          release: ${{ env.ABI_VERSION }}/edge
+          release: ${{ env.RELEASE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           echo "RUBY_VERSION=$RAW_RUBY_VERSION" >> $GITHUB_ENV
 
       - name: Generate template file
-        run: ruby generate.rb ${{ env.RUBY_VERSION }}
+        run: ruby generate.rb "$RUBY_VERSION"
 
       - uses:  snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
         id: snapcraft
@@ -90,7 +90,7 @@ jobs:
           echo "RUBY_VERSION=$RAW_RUBY_VERSION" >> $GITHUB_ENV
 
       - name: Generate template file
-        run: ruby generate.rb ${{ env.RUBY_VERSION }}
+        run: ruby generate.rb "$RUBY_VERSION"
 
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,12 @@ jobs:
             fi
             echo "RELEASE=$RELEASE" >> $GITHUB_ENV
           else
-            echo "RELEASE=$ABI_VERSION/edge" >> $GITHUB_ENV
+            # preview/rc builds are not published; latest/edge tracks master.
+            echo "RELEASE=" >> $GITHUB_ENV
           fi
 
       - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
+        if: env.RELEASE != ''
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
@@ -108,10 +110,12 @@ jobs:
             fi
             echo "RELEASE=$RELEASE" >> $GITHUB_ENV
           else
-            echo "RELEASE=$ABI_VERSION/edge" >> $GITHUB_ENV
+            # preview/rc builds are not published; latest/edge tracks master.
+            echo "RELEASE=" >> $GITHUB_ENV
           fi
 
       - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
+        if: env.RELEASE != ''
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,13 +5,19 @@ on:
     - cron: '0 17 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
 env:
-  # Development version that master (snapshot.tar.gz) currently builds.
-  MASTER_VERSION: '4.1.0'
+  # Latest stable ABI series. master builds the next series (minor + 1,
+  # carrying x.5 over to the next major .0), e.g. 4.0 -> 4.1, 3.5 -> 4.0.
+  LATEST_STABLE_TRACK: '4.0'
 
 jobs:
   build:
     name: build master with snapcraft
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,10 +31,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Store Ruby version
-        run: echo "RUBY_VERSION=$MASTER_VERSION" >> $GITHUB_ENV
+        run: |
+          RUBY_VERSION=$(ruby -e 'major, minor = ENV["LATEST_STABLE_TRACK"].split(".").map(&:to_i); if minor >= 5 then major += 1; minor = 0 else minor += 1 end; puts "#{major}.#{minor}.0"')
+          echo "RUBY_VERSION=$RUBY_VERSION" >> "$GITHUB_ENV"
 
       - name: Generate template file
-        run: ruby generate.rb ${{ env.RUBY_VERSION }}
+        run: ruby generate.rb "$RUBY_VERSION"
 
       - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
         id: snapcraft
@@ -44,16 +52,19 @@ jobs:
 
   build-armhf:
     name: build master armhf with snapcraft
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Store Ruby version
-        run: echo "RUBY_VERSION=$MASTER_VERSION" >> $GITHUB_ENV
+        run: |
+          RUBY_VERSION=$(ruby -e 'major, minor = ENV["LATEST_STABLE_TRACK"].split(".").map(&:to_i); if minor >= 5 then major += 1; minor = 0 else minor += 1 end; puts "#{major}.#{minor}.0"')
+          echo "RUBY_VERSION=$RUBY_VERSION" >> "$GITHUB_ENV"
 
       - name: Generate template file
-        run: ruby generate.rb ${{ env.RUBY_VERSION }}
+        run: ruby generate.rb "$RUBY_VERSION"
 
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,70 @@
+name: nightly
+
+on:
+  schedule:
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+
+env:
+  # Development version that master (snapshot.tar.gz) currently builds.
+  MASTER_VERSION: '4.1.0'
+
+jobs:
+  build:
+    name: build master with snapcraft
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - platform: amd64
+            os: ubuntu-24.04
+          - platform: arm64
+            os: ubuntu-24.04-arm
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Store Ruby version
+        run: echo "RUBY_VERSION=$MASTER_VERSION" >> $GITHUB_ENV
+
+      - name: Generate template file
+        run: ruby generate.rb ${{ env.RUBY_VERSION }}
+
+      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
+        id: snapcraft
+        with:
+          snapcraft-args: --target-arch=${{ matrix.platform }} --enable-experimental-target-arch
+
+      - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: latest/edge
+
+  build-armhf:
+    name: build master armhf with snapcraft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Store Ruby version
+        run: echo "RUBY_VERSION=$MASTER_VERSION" >> $GITHUB_ENV
+
+      - name: Generate template file
+        run: ruby generate.rb ${{ env.RUBY_VERSION }}
+
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - uses: diddlesnaps/snapcraft-multiarch-action@cfd7a246fad6bea65bb92f69a1c8d07898c231e5 # v1.9.0
+        id: snapcraft
+        with:
+          architecture: armhf
+
+      - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: latest/edge


### PR DESCRIPTION
Stable X.Y.Z releases now go to their per-series stable channel, and the current latest stable series also lands on the default trackless stable channel so a plain snap install ruby follows it. The series that owns the default channel is configured once through LATEST_STABLE_TRACK.

A new nightly workflow builds the master snapshot and publishes it to latest/edge so edge always tracks trunk. Because master owns edge now, the release workflow no longer pushes preview or rc builds to edge.

The dispatched ruby version came from repository_dispatch client_payload and was expanded straight into a run block. It now passes through env and is validated against a version format so it can no longer inject shell commands or extra GITHUB_ENV entries.
